### PR TITLE
feat: new component: kubectl-manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ Library of common components for use with nuon apps.
 ├── README.md
 └── aws
     ├── certificate
+    ├── kubectl-manifest
     └── rds-cluster
 ```

--- a/aws/kubectl-manifest/README.md
+++ b/aws/kubectl-manifest/README.md
@@ -1,0 +1,42 @@
+# Kubeclt Manifest
+
+Cloud agnostic tf module w/ `kubectl` provider to apply arbitrary k8s manifests.
+
+## Inputs/Variables
+
+| Variable     | Description                                               | Example                                                        |
+| ------------ | --------------------------------------------------------- | -------------------------------------------------------------- |
+| install_name | The install id                                            | `{{.nuon.install.id}}`                                         |
+| cluster_name | The name of the cluster - sourced from the sandbox.       | `{{.nuon.install.sandbox.outputs.cluster.name}}`               |
+| iam_role_arn | The name of the role to invoke the `aws eks` cli cmd with | `{{.nuon.install.sandbox.outputs.runner.runner_iam_role_arn}}` |
+| yaml_body    | YAML k8s manifest - multi-line string                     |                                                                |
+
+## Example Configuration
+
+```toml
+name = "kubectl_manifest"
+type = "terraform_module"
+terraform_version = "1.9.3"
+
+[public_repo]
+repo      = "nuonco/components"
+directory = "kubectl-manifest"
+branch    = "main"
+
+[vars]
+install_name = "{{.nuon.install.id}}"
+cluster_name = "{{.nuon.install.sandbox.outputs.cluster.name}}"
+iam_role_arn = "{{.nuon.install.sandbox.outputs.runner.runner_iam_role_arn}}"
+yaml_body = """
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: api-configs
+  namespace: {{.nuon.install.id}}
+data:
+  DEBUG: {{.nuon.install.inputs.debug}}
+  LOG_LEVEL: {{.nuon.install.inputs.log_level}}
+  PORT: {{.nuon.install.inputs.port}}
+"""
+```

--- a/aws/kubectl-manifest/main.tf
+++ b/aws/kubectl-manifest/main.tf
@@ -1,0 +1,3 @@
+resource "kubectl_manifest" "manifest" {
+  yaml_body = yamlencode(yamldecode(var.yaml_body))
+}

--- a/aws/kubectl-manifest/outputs.tf
+++ b/aws/kubectl-manifest/outputs.tf
@@ -1,0 +1,4 @@
+// NOTE(fd): pass-through output - saw issues w/ component w/out outputs
+output "install_name" {
+  value = var.install_name
+}

--- a/aws/kubectl-manifest/providers.tf
+++ b/aws/kubectl-manifest/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {}
+
+provider "kubectl" {
+  load_config_file = false
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", var.cluster_name, "--role-arn", var.iam_role_arn]
+  }
+}

--- a/aws/kubectl-manifest/variables.tf
+++ b/aws/kubectl-manifest/variables.tf
@@ -1,0 +1,23 @@
+variable "install_name" {
+  type        = string
+  description = "The name of this install. Will be used for the EKS cluster, various tags, and other resources."
+  default     = ""
+}
+
+variable "iam_role_arn" {
+  type        = string
+  description = "The IAM Role to get EKS credentials with/for."
+  default     = ""
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster to get EKS credentials for."
+  default     = ""
+}
+
+variable "yaml_body" {
+  type        = string
+  description = "The yaml body of the manifest."
+  default     = ""
+}

--- a/aws/kubectl-manifest/versions.tf
+++ b/aws/kubectl-manifest/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.67.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.14"
+    }
+  }
+}


### PR DESCRIPTION
### Notes

Tested with the following component config: `components/kubect_manifest.toml`

```toml
name = "kubectl_manifest"
type = "terraform_module"
terraform_version = "1.9.8"

[public_repo]
repo      = "nuonco/components"
directory = "aws/kubectl-manifest"
branch    = "fd/new/kubectl-manifest"

[vars]
install_name = "{{.nuon.install.id}}"
cluster_name = "{{.nuon.install.sandbox.outputs.cluster.name}}"
iam_role_arn = "{{.nuon.install.sandbox.outputs.runner.runner_iam_role_arn}}"
yaml_body = """
---
apiVersion: v1
kind: ConfigMap
metadata:
  namespace: {{.nuon.install.id}}
  name: api-configs
data:
  DEBUG: "{{.nuon.install.inputs.debug}}"
  USE_INSECURE_COOKIES: "{{.nuon.install.inputs.use_insecure_cookies}}"
  LOG_LEVEL: "{{.nuon.install.inputs.log_level}}"
  PORT: "{{.nuon.install.inputs.port}}"
"""

```