### PR TITLE
chore: remove backend and fix default_tags

### DIFF
--- a/aws/rds-subnet/providers.tf
+++ b/aws/rds-subnet/providers.tf
@@ -1,4 +1,6 @@
 provider "aws" {
-  region       = var.region
-  default_tags = local.tags
+  region = var.region
+  default_tags {
+    tags = local.tags
+  }
 }

--- a/aws/rds-subnet/versions.tf
+++ b/aws/rds-subnet/versions.tf
@@ -1,8 +1,6 @@
 terraform {
   required_version = ">= 1.7.5"
 
-  backend "s3" {}
-
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
the new version of the terraform component deploys configures this
backend directly and this config collides. 

### Notes

This change is not backwards compatible.